### PR TITLE
Simplify some instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Quick presentation of a node.js workflow with Kubernetes.
 
 - [minikube](https://github.com/kubernetes/minikube#what-is-minikube)
 - [skaffold](https://github.com/GoogleContainerTools/skaffold#installation)
-- docker client (e.g. `brew install docker`)
 
 ## Simple Example
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,6 @@ Download the repo
 git clone https://github.com/philips/skaffold-nodejs-example
 ```
 
-Manually build the container 
-
-```
-eval $(minikube docker-env)
-docker build .
-```
-
 Start the workflow
 
 ```


### PR DESCRIPTION
If these are used as part of the presentation, feel free to ignore :)

* No need to run `eval $(minikube docker-env)` with skaffold when using minikube! (the equivalent happens automatically)

* There's not actually a dependency on the docker CLI for skaffold since it doesn't shell out but calls the API directly through the client library. Although I'm not sure how far you'll get with docker development without the docker CLI.